### PR TITLE
Fix multiple interfaces example

### DIFF
--- a/public/documentation/object-programming/object-expressions.md
+++ b/public/documentation/object-programming/object-expressions.md
@@ -35,7 +35,7 @@ let square =
             printfn $"Drawing a square @ X: {x}, Y: {y}" }
 
 square.Kind // "square"
-(square :> IDrawable).Draw(0.0, 0.0) // "Drawing a square @ X: 0.0, Y: 0.0"
+square.Draw(0.0, 0.0) // "Drawing a square @ X: 0.0, Y: 0.0"
 ```
 
-Notice that the type of `square` is an `IShape` as that's what its created as when using `new IShape with`. It just so happens that it also implements the `IDrawable` interface and casting is required to convert it to an `IDrawable`
+Notice that the type of `square` is an `ISquare` as that's what it's created as when using `new ISquare with`.

--- a/public/documentation/object-programming/object-expressions.md
+++ b/public/documentation/object-programming/object-expressions.md
@@ -23,11 +23,14 @@ type IShape =
 type IDrawable =
     abstract member Draw : float * float -> unit
 
+type ISquare =
+  inherit IShape
+  inherit IDrawable
+
 let square =
-    { new IShape with
+    { new ISquare with
         member this.Kind = "square"
-        
-      new IDrawable with
+
         member this.Draw(x: float, y: float) =
             printfn $"Drawing a square @ X: {x}, Y: {y}" }
 


### PR DESCRIPTION
Only way I could get it to work was to create a new interface `ISquare` that inherited both interfaces to new that interface. Seems that shouldn't be needed though...

The current example as-is gives me the following errors:

```
Incomplete value or function definition. If this is in an expression, the body of the expression must be indented to the same column as the 'let' keyword.

Unmatched '{'

Unexpected keyword 'new' in expression. Expected '}' or other token.

Incomplete structured construct at or before this point in binding. Expected incomplete structured construct at or before this point or other token.
```